### PR TITLE
Replace DateTime with Time

### DIFF
--- a/lib/expire/backup.rb
+++ b/lib/expire/backup.rb
@@ -6,7 +6,7 @@ module Expire
     include Comparable
 
     def initialize(time:, pathname:)
-      @time = time
+      @time     = time
       @pathname = pathname
 
       # @reasons_to_keep is a Set so a reason can added multiple times

--- a/lib/expire/backup.rb
+++ b/lib/expire/backup.rb
@@ -5,8 +5,8 @@ module Expire
   class Backup < Delegator
     include Comparable
 
-    def initialize(datetime:, pathname:)
-      @datetime = datetime
+    def initialize(time:, pathname:)
+      @time = time
       @pathname = pathname
 
       # @reasons_to_keep is a Set so a reason can added multiple times
@@ -14,8 +14,8 @@ module Expire
       @reasons_to_keep = Set.new
     end
 
-    attr_reader :datetime, :pathname, :reasons_to_keep
-    alias __getobj__ datetime
+    attr_reader :time, :pathname, :reasons_to_keep
+    alias __getobj__ time
 
     def same_hour?(other)
       return false unless same_day?(other)
@@ -52,16 +52,20 @@ module Expire
     # The <=> method seems not to be delegated so we need to implement it
     # Note that this Class includes the Comparable module
     def <=>(other)
-      datetime <=> other.datetime
+      time <=> other.time
     end
 
     def add_reason_to_keep(reason)
       reasons_to_keep << reason
     end
 
-    # def datetime
-    #   backup.datetime
+    # def time
+    #   backup.time
     # end
+
+    def cweek
+      time&.strftime('%V').to_i
+    end
 
     def expired?
       reasons_to_keep.empty?
@@ -69,6 +73,10 @@ module Expire
 
     def keep?
       reasons_to_keep.any?
+    end
+
+    def to_s
+      time.strftime('%Y-%m-%dT%H:%M')
     end
   end
 end

--- a/lib/expire/backup_from_path_service.rb
+++ b/lib/expire/backup_from_path_service.rb
@@ -35,7 +35,7 @@ module Expire
       Date.new(year, month, day)
       Time.new(year, month, day, hour, minute)
     rescue Date::Error
-      raise InvalidPathError, "can't construct date and time from #{pathname}" 
+      raise InvalidPathError, "can't construct date and time from #{pathname}"
     rescue ArgumentError
       raise InvalidPathError, "can't construct date and time from #{pathname}"
     end

--- a/lib/expire/backup_from_path_service.rb
+++ b/lib/expire/backup_from_path_service.rb
@@ -3,15 +3,12 @@
 module Expire
   # Take a path and return an instance of Expire::Backup
   class BackupFromPathService
-    def self.call(path:, by: :path)
-      new(path: path, by: by).call
+    def self.call(path:)
+      new(path: path).call
     end
 
-    def initialize(path:, by: :path)
-      @by       = by
+    def initialize(path:)
       @pathname = Pathname.new(path)
-
-      raise ArgumentError, "by: must be :ctime, :mtime or :path, not #{by}" unless %i[ctime mtime path].include?(by)
     end
 
     attr_reader :by, :pathname

--- a/lib/expire/backup_from_path_service.rb
+++ b/lib/expire/backup_from_path_service.rb
@@ -17,12 +17,12 @@ module Expire
     attr_reader :by, :pathname
 
     def call
-      Backup.new(datetime: datetime, pathname: pathname)
+      Backup.new(time: time, pathname: pathname)
     end
 
     private
 
-    def datetime
+    def time
       digits = extract_digits
 
       year   = digits[0..3].to_i
@@ -31,13 +31,16 @@ module Expire
       hour   = digits[8..9].to_i
       minute = digits[10..11].to_i
 
-      datetime_for(year, month, day, hour, minute)
+      time_for(year, month, day, hour, minute)
     end
 
-    def datetime_for(year, month, day, hour, minute)
-      DateTime.new(year, month, day, hour, minute)
+    def time_for(year, month, day, hour, minute)
+      Date.new(year, month, day)
+      Time.new(year, month, day, hour, minute)
     rescue Date::Error
       raise InvalidPathError, "can't construct date and time from #{pathname}" 
+    rescue ArgumentError
+      raise InvalidPathError, "can't construct date and time from #{pathname}"
     end
 
     def extract_digits

--- a/lib/expire/backup_list.rb
+++ b/lib/expire/backup_list.rb
@@ -46,8 +46,8 @@ module Expire
       backups.min
     end
 
-    def not_older_than(reference_datetime)
-      sort.select { |backup| backup.datetime >= reference_datetime }
+    def not_older_than(reference_time)
+      sort.select { |backup| backup.time >= reference_time }
     end
 
     def expired

--- a/lib/expire/cli.rb
+++ b/lib/expire/cli.rb
@@ -90,6 +90,7 @@ module Expire
         Expire::Commands::Newest.new(path, options).execute
       end
     end
+
     # Play with test-data
     class Playground < Thor
       desc 'create PATH', 'play with test-data'

--- a/lib/expire/from_now_keep_adjective_for_rule_base.rb
+++ b/lib/expire/from_now_keep_adjective_for_rule_base.rb
@@ -20,9 +20,9 @@ module Expire
 
     attr_reader :unit
 
-    def apply(backups, reference_datetime)
-      minimal_datetime = reference_datetime - amount.send(unit)
-      kept = backups.one_per(spacing).not_older_than(minimal_datetime)
+    def apply(backups, reference_time)
+      minimal_time = reference_time - amount.send(unit)
+      kept = backups.one_per(spacing).not_older_than(minimal_time)
 
       kept.each { |backup| backup.add_reason_to_keep(reason_to_keep) }
     end

--- a/lib/expire/from_now_keep_most_recent_for_rule.rb
+++ b/lib/expire/from_now_keep_most_recent_for_rule.rb
@@ -21,9 +21,9 @@ module Expire
 
     attr_reader :unit
 
-    def apply(backups, datetime_now)
-      reference_datetime = datetime_now - amount.send(unit)
-      kept = backups.not_older_than(reference_datetime)
+    def apply(backups, time_now)
+      reference_time = time_now - amount.send(unit)
+      kept = backups.not_older_than(reference_time)
 
       kept.each do |backup|
         backup.add_reason_to_keep(reason_to_keep)

--- a/lib/expire/from_range_value.rb
+++ b/lib/expire/from_range_value.rb
@@ -11,7 +11,7 @@ module Expire
     (\s+|\.)
     (hour|day|week|month|year)s?
     \z
-    /x.freeze
+    /x
 
     def from_value(string, **args)
       # return new(args.merge({ amount: 0, unit: nil })) if string.none?

--- a/lib/expire/keep_most_recent_for_rule.rb
+++ b/lib/expire/keep_most_recent_for_rule.rb
@@ -16,8 +16,8 @@ module Expire
     end
 
     def apply(backups, _)
-      reference_datetime = backups.newest
-      super(backups, reference_datetime)
+      reference_time = backups.newest
+      super(backups, reference_time)
     end
 
     def rank

--- a/lib/expire/playground.rb
+++ b/lib/expire/playground.rb
@@ -33,7 +33,7 @@ module Expire
     def create
       raise_if_backups_dir_exists
 
-      oldest_backup = DateTime.now
+      oldest_backup = Time.now
 
       STEP_WIDTHS.each do |adjective, noun|
         options[adjective.to_sym].times do
@@ -45,8 +45,8 @@ module Expire
 
     private
 
-    def mkbackup(datetime)
-      backup_name = datetime.to_s.sub(/:\d\d[+-]\d\d:\d\d\z/, '')
+    def mkbackup(time)
+      backup_name = time.strftime('%Y-%m-%dT%H:%M')
       FileUtils.mkdir_p("#{backups_dir}/#{backup_name}")
     end
 

--- a/lib/expire/purge_service.rb
+++ b/lib/expire/purge_service.rb
@@ -25,7 +25,7 @@ module Expire
     private
 
     def annotated_backup_list
-      @annotated_backup_list ||= rules.apply(backup_list, DateTime.now)
+      @annotated_backup_list ||= rules.apply(backup_list, Time.now)
     end
 
     def backup_list

--- a/lib/expire/rules.rb
+++ b/lib/expire/rules.rb
@@ -35,8 +35,8 @@ module Expire
       rules.any?
     end
 
-    def apply(backups, reference_datetime)
-      rules.sort.each { |rule| rule.apply(backups, reference_datetime) }
+    def apply(backups, reference_time)
+      rules.sort.each { |rule| rule.apply(backups, reference_time) }
 
       backups
     end

--- a/spec/default_test_dates.rb
+++ b/spec/default_test_dates.rb
@@ -33,7 +33,7 @@ class DefaultTestDates < TestDates
 
         Expire::Backup.new(
           time: Time.new(*time),
-          path:     path
+          path: path
         )
       end
     )

--- a/spec/default_test_dates.rb
+++ b/spec/default_test_dates.rb
@@ -28,11 +28,11 @@ class DefaultTestDates < TestDates
 
   def to_backup_list
     Expire::BackupList.new(
-      result.map do |datetime|
-        path = Pathname.new("backups/#{datetime[0..5].join('-')}")
+      result.map do |time|
+        path = Pathname.new("backups/#{time[0..5].join('-')}")
 
         Expire::Backup.new(
-          datetime: DateTime.new(*datetime),
+          time: Time.new(*time),
           path:     path
         )
       end

--- a/spec/expire/backup_from_path_service_spec.rb
+++ b/spec/expire/backup_from_path_service_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Expire::BackupFromPathService do
           expect(service.call).to be_instance_of(Expire::Backup)
         end
 
-        it 'returns a Backup with the expected datetime' do
-          expect(service.call.datetime).to eq(DateTime.new(2021, 1, 2, 3, 4))
+        it 'returns a Backup with the expected time' do
+          expect(service.call.time).to eq(Time.new(2021, 1, 2, 3, 4))
         end
       end
     end

--- a/spec/expire/backup_from_path_service_spec.rb
+++ b/spec/expire/backup_from_path_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Expire::BackupFromPathService do
       /1/22/345/20210102T03:04:59
     ].each do |path|
       context "with path #{path}" do
-        let(:service) { described_class.new(path: path, by: :path) }
+        let(:service) { described_class.new(path: path) }
 
         it 'returns an instance of Expire::Backup' do
           expect(service.call).to be_instance_of(Expire::Backup)
@@ -21,7 +21,7 @@ RSpec.describe Expire::BackupFromPathService do
     end
 
     context 'with to much numbers' do
-      let(:service) { described_class.new(path: '/backups/2021-01-19T20:21:22extra123, by: :path') }
+      let(:service) { described_class.new(path: '/backups/2021-01-19T20:21:22extra123') }
 
       it 'raises an InvalidPathError' do
         expect { service.call }.to raise_error(Expire::InvalidPathError, /can't extract/)
@@ -29,7 +29,7 @@ RSpec.describe Expire::BackupFromPathService do
     end
 
     context 'without enough numbers' do
-      let(:service) { described_class.new(path: '/backups/2021-01-19T20, by: :path') }
+      let(:service) { described_class.new(path: '/backups/2021-01-19T20') }
 
       it 'raises an InvalidPathError' do
         expect { service.call }.to raise_error(Expire::InvalidPathError, /can't extract/)
@@ -37,7 +37,7 @@ RSpec.describe Expire::BackupFromPathService do
     end
 
     context 'with 13 numbers' do
-      let(:service) { described_class.new(path: '/backups/1234567890123', by: :path) }
+      let(:service) { described_class.new(path: '/backups/1234567890123') }
 
       it 'raises an InvalidPathError' do
         expect { service.call }.to raise_error(Expire::InvalidPathError, /can't extract/)
@@ -45,7 +45,7 @@ RSpec.describe Expire::BackupFromPathService do
     end
 
     context 'without any numbers' do
-      let(:service) { described_class.new(path: '/backups/hello_world', by: :path) }
+      let(:service) { described_class.new(path: '/backups/hello_world') }
 
       it 'raises an InvalidPathError' do
         expect { service.call }.to raise_error(Expire::InvalidPathError, /can't extract/)
@@ -53,7 +53,7 @@ RSpec.describe Expire::BackupFromPathService do
     end
 
     context 'with a path representing an invalid date' do
-      let(:service) { described_class.new(path: '/backups/2021-02-31T11:12', by: :path) }
+      let(:service) { described_class.new(path: '/backups/2021-02-31T11:12') }
 
       it 'raises an InvalidPathError' do
         expect { service.call }.to raise_error(Expire::InvalidPathError, /can't construct/)
@@ -61,7 +61,7 @@ RSpec.describe Expire::BackupFromPathService do
     end
 
     context 'with a path representing an invalid time' do
-      let(:service) { described_class.new(path: '/backups/2021-02-12T25:12', by: :path) }
+      let(:service) { described_class.new(path: '/backups/2021-02-12T25:12') }
 
       it 'raises an InvalidPathError' do
         expect { service.call }.to raise_error(Expire::InvalidPathError, /can't construct/)

--- a/spec/expire/backup_list_spec.rb
+++ b/spec/expire/backup_list_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe Expire::BackupList do
       described_class.new(
         [
           Expire::Backup.new(
-            time: Time.new(1860, 5, 17, 12, 0, 0),
+            time:     Time.new(1860, 5, 17, 12, 0, 0),
             pathname: Pathname.new('backups/oldest')
           ),
 
           Expire::Backup.new(
-            time: Time.new(1860, 5, 17, 12, 44, 0),
+            time:     Time.new(1860, 5, 17, 12, 44, 0),
             pathname: Pathname.new('backups/newest')
           ),
           Expire::Backup.new(
-            time: Time.new(1860, 5, 17, 12, 36, 0),
+            time:     Time.new(1860, 5, 17, 12, 36, 0),
             pathname: Pathname.new('backups/middle')
           )
         ]
@@ -93,12 +93,12 @@ RSpec.describe Expire::BackupList do
       described_class.new(
         [
           Expire::Backup.new(
-            time: Time.new(1860, 5, 17, 12, 0, 0),
+            time:     Time.new(1860, 5, 17, 12, 0, 0),
             pathname: Pathname.new('fake_path')
           ),
 
           Expire::Backup.new(
-            time: Time.new(1860, 5, 17, 12, 44, 0),
+            time:     Time.new(1860, 5, 17, 12, 44, 0),
             pathname: Pathname.new('fake_path')
           )
         ]
@@ -152,26 +152,26 @@ RSpec.describe Expire::BackupList do
         described_class.new(
           [
             Expire::Backup.new(
-              time: Time.new(1860, 5, 17, 12, 0, 0),
+              time:     Time.new(1860, 5, 17, 12, 0, 0),
               pathname: Pathname.new('fake_path')
             ),
 
             Expire::Backup.new(
-              time: Time.new(1860, 5, 17, 12, 44, 0),
+              time:     Time.new(1860, 5, 17, 12, 44, 0),
               pathname: Pathname.new('fake_path')
             ),
             Expire::Backup.new(
-              time: Time.new(1860, 5, 17, 12, 36, 0),
-              pathname: Pathname.new('fake_path')
-            ),
-
-            Expire::Backup.new(
-              time: Time.new(1860, 5, 17, 12, 33, 0),
+              time:     Time.new(1860, 5, 17, 12, 36, 0),
               pathname: Pathname.new('fake_path')
             ),
 
             Expire::Backup.new(
-              time: Time.new(1860, 5, 17, 13, 0, 0),
+              time:     Time.new(1860, 5, 17, 12, 33, 0),
+              pathname: Pathname.new('fake_path')
+            ),
+
+            Expire::Backup.new(
+              time:     Time.new(1860, 5, 17, 13, 0, 0),
               pathname: Pathname.new('fake_path')
             )
           ]
@@ -186,11 +186,11 @@ RSpec.describe Expire::BackupList do
       it 'returns hourly backups' do
         expect(hourly).to contain_exactly(
           Expire::Backup.new(
-            time: Time.new(1860, 5, 17, 12, 44, 0),
+            time:     Time.new(1860, 5, 17, 12, 44, 0),
             pathname: :fake_path
           ),
           Expire::Backup.new(
-            time: Time.new(1860, 5, 17, 13, 0, 0),
+            time:     Time.new(1860, 5, 17, 13, 0, 0),
             pathname: :fake_path
           )
         )

--- a/spec/expire/backup_list_spec.rb
+++ b/spec/expire/backup_list_spec.rb
@@ -16,16 +16,16 @@ RSpec.describe Expire::BackupList do
       described_class.new(
         [
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+            time: Time.new(1860, 5, 17, 12, 0, 0),
             pathname: Pathname.new('backups/oldest')
           ),
 
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 44, 0),
+            time: Time.new(1860, 5, 17, 12, 44, 0),
             pathname: Pathname.new('backups/newest')
           ),
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 36, 0),
+            time: Time.new(1860, 5, 17, 12, 36, 0),
             pathname: Pathname.new('backups/middle')
           )
         ]
@@ -69,12 +69,12 @@ RSpec.describe Expire::BackupList do
       described_class.new(
         [
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+            time:     Time.new(1860, 5, 17, 12, 0, 0),
             pathname: Pathname.new('fake_path')
           ),
 
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 44, 0),
+            time:     Time.new(1860, 5, 17, 12, 44, 0),
             pathname: Pathname.new('fake_path')
           )
         ]
@@ -93,12 +93,12 @@ RSpec.describe Expire::BackupList do
       described_class.new(
         [
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+            time: Time.new(1860, 5, 17, 12, 0, 0),
             pathname: Pathname.new('fake_path')
           ),
 
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 44, 0),
+            time: Time.new(1860, 5, 17, 12, 44, 0),
             pathname: Pathname.new('fake_path')
           )
         ]
@@ -116,31 +116,31 @@ RSpec.describe Expire::BackupList do
     let(:backups) { TestDates.create(days: 15..17).to_backups }
 
     context 'with no backup not older than reference time' do
-      let(:reference_datetime) { DateTime.new(1860, 5, 17, 12, 0, 1) }
+      let(:reference_time) { Time.new(1860, 5, 17, 12, 0, 1) }
       let(:kept) { described_class.new }
 
       it 'returns all backups not older than the reference time' do
-        expect(backups.not_older_than(reference_datetime))
+        expect(backups.not_older_than(reference_time))
           .to contain_exactly(*kept)
       end
     end
 
     context 'with all backups not older than reference time' do
-      let(:reference_datetime) { DateTime.new(1860, 5, 15, 12, 0, 0) }
+      let(:reference_time) { Time.new(1860, 5, 15, 12, 0, 0) }
       let(:kept) { TestDates.create(days: 15..17).to_backups }
 
       it 'returns all backups not older than the reference time' do
-        expect(backups.not_older_than(reference_datetime))
+        expect(backups.not_older_than(reference_time))
           .to contain_exactly(*kept)
       end
     end
 
     context 'with some backups not older than reference time' do
-      let(:reference_datetime) { DateTime.new(1860, 5, 15, 12, 0, 1) }
+      let(:reference_time) { Time.new(1860, 5, 15, 12, 0, 1) }
       let(:kept) { TestDates.create(days: 16..17).to_backups }
 
       it 'returns all backups not older than the reference time' do
-        expect(backups.not_older_than(reference_datetime))
+        expect(backups.not_older_than(reference_time))
           .to contain_exactly(*kept)
       end
     end
@@ -152,26 +152,26 @@ RSpec.describe Expire::BackupList do
         described_class.new(
           [
             Expire::Backup.new(
-              datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+              time: Time.new(1860, 5, 17, 12, 0, 0),
               pathname: Pathname.new('fake_path')
             ),
 
             Expire::Backup.new(
-              datetime: DateTime.new(1860, 5, 17, 12, 44, 0),
+              time: Time.new(1860, 5, 17, 12, 44, 0),
               pathname: Pathname.new('fake_path')
             ),
             Expire::Backup.new(
-              datetime: DateTime.new(1860, 5, 17, 12, 36, 0),
-              pathname: Pathname.new('fake_path')
-            ),
-
-            Expire::Backup.new(
-              datetime: DateTime.new(1860, 5, 17, 12, 33, 0),
+              time: Time.new(1860, 5, 17, 12, 36, 0),
               pathname: Pathname.new('fake_path')
             ),
 
             Expire::Backup.new(
-              datetime: DateTime.new(1860, 5, 17, 13, 0, 0),
+              time: Time.new(1860, 5, 17, 12, 33, 0),
+              pathname: Pathname.new('fake_path')
+            ),
+
+            Expire::Backup.new(
+              time: Time.new(1860, 5, 17, 13, 0, 0),
               pathname: Pathname.new('fake_path')
             )
           ]
@@ -186,11 +186,11 @@ RSpec.describe Expire::BackupList do
       it 'returns hourly backups' do
         expect(hourly).to contain_exactly(
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 12, 44, 0),
+            time: Time.new(1860, 5, 17, 12, 44, 0),
             pathname: :fake_path
           ),
           Expire::Backup.new(
-            datetime: DateTime.new(1860, 5, 17, 13, 0, 0),
+            time: Time.new(1860, 5, 17, 13, 0, 0),
             pathname: :fake_path
           )
         )

--- a/spec/expire/backup_spec.rb
+++ b/spec/expire/backup_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Expire::Backup do
   subject do
     described_class.new(
-      datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+      time: Time.new(1860, 5, 17, 12, 0, 0),
       pathname: Pathname.new('backups/1860-05-17_12_00_00')
     )
   end
@@ -15,7 +15,7 @@ RSpec.describe Expire::Backup do
   describe '#same_hour?' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -23,7 +23,7 @@ RSpec.describe Expire::Backup do
     context 'when the hour is the same' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 17, 12, 11, 22),
+          time: Time.new(1860, 5, 17, 12, 11, 22),
           pathname: Pathname.new('backups/1860-05-17_12_11_22')
         )
       end
@@ -36,7 +36,7 @@ RSpec.describe Expire::Backup do
     context 'when the hour differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 17, 13, 0, 0),
+          time: Time.new(1860, 5, 17, 13, 0, 0),
           pathname: Pathname.new('backups/1860-05-17_13_00_00')
         )
       end
@@ -49,7 +49,7 @@ RSpec.describe Expire::Backup do
     context 'when the day differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 22, 12, 0, 0),
+          time: Time.new(1860, 5, 22, 12, 0, 0),
           pathname: Pathname.new('backups/1860-05-22_12_00_00')
         )
       end
@@ -63,7 +63,7 @@ RSpec.describe Expire::Backup do
   describe '#same_day?' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -71,7 +71,7 @@ RSpec.describe Expire::Backup do
     context 'when the day is the same' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 17, 23, 11, 22),
+          time: Time.new(1860, 5, 17, 23, 11, 22),
           pathname: Pathname.new('backups/1860-05-17_23_11_22')
         )
       end
@@ -84,7 +84,7 @@ RSpec.describe Expire::Backup do
     context 'when the day differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 18, 13, 0, 0),
+          time: Time.new(1860, 5, 18, 13, 0, 0),
           pathname: Pathname.new('backups/1860-05-18_13_00_00')
         )
       end
@@ -97,7 +97,7 @@ RSpec.describe Expire::Backup do
     context 'when the month differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 4, 22, 12, 0, 0),
+          time: Time.new(1860, 4, 22, 12, 0, 0),
           pathname: Pathname.new('backups/1860-04-22_12_00_00')
         )
       end
@@ -111,7 +111,7 @@ RSpec.describe Expire::Backup do
   describe '#same_week?' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -119,7 +119,7 @@ RSpec.describe Expire::Backup do
     context 'when the week is the same' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 15, 12, 0, 0),
+          time: Time.new(1860, 5, 15, 12, 0, 0),
           pathname: Pathname.new('backups/1860-05-15_12_00_00')
         )
       end
@@ -132,7 +132,7 @@ RSpec.describe Expire::Backup do
     context 'when the week differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 22, 13, 0, 0),
+          time: Time.new(1860, 5, 22, 13, 0, 0),
           pathname: Pathname.new('backups/1860-05-22_13_00_00')
         )
       end
@@ -145,7 +145,7 @@ RSpec.describe Expire::Backup do
     context 'when the month differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 4, 15, 22, 0, 0),
+          time: Time.new(1860, 4, 15, 22, 0, 0),
           pathname: Pathname.new('backups/1860-04-15_22_00_00')
         )
       end
@@ -159,7 +159,7 @@ RSpec.describe Expire::Backup do
   describe '#same_month?' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -167,7 +167,7 @@ RSpec.describe Expire::Backup do
     context 'when the month is the same' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 5, 1, 12, 0, 0),
+          time: Time.new(1860, 5, 1, 12, 0, 0),
           pathname: Pathname.new('backups/1860-01-12_12_00_00')
         )
       end
@@ -180,7 +180,7 @@ RSpec.describe Expire::Backup do
     context 'when the month differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 3, 17, 13, 0, 0),
+          time: Time.new(1860, 3, 17, 13, 0, 0),
           pathname: Pathname.new('backups/1860-03-17_13_00_00')
         )
       end
@@ -193,7 +193,7 @@ RSpec.describe Expire::Backup do
     context 'when the year differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1859, 5, 17, 12, 0, 0),
+          time: Time.new(1859, 5, 17, 12, 0, 0),
           pathname: Pathname.new('backups/1860-05-17_12_00_00')
         )
       end
@@ -207,7 +207,7 @@ RSpec.describe Expire::Backup do
   describe '#same_year?' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -215,7 +215,7 @@ RSpec.describe Expire::Backup do
     context 'when the year is the same' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1860, 2, 15, 1, 10, 30),
+          time: Time.new(1860, 2, 15, 1, 10, 30),
           pathname: Pathname.new('backups/1860-05-15_01_10_30')
         )
       end
@@ -228,7 +228,7 @@ RSpec.describe Expire::Backup do
     context 'when the year differs' do
       let(:other) do
         described_class.new(
-          datetime: DateTime.new(1859, 5, 17, 12, 0, 0),
+          time: Time.new(1859, 5, 17, 12, 0, 0),
           pathname: Pathname.new('backups/1859-05-17_12_00_00')
         )
       end
@@ -242,7 +242,7 @@ RSpec.describe Expire::Backup do
   describe '#expired?' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -265,7 +265,7 @@ RSpec.describe Expire::Backup do
   describe '#keep?' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -288,7 +288,7 @@ RSpec.describe Expire::Backup do
   describe '#reasons_to_keep' do
     let(:backup) do
       described_class.new(
-        datetime: DateTime.new(1860, 5, 17, 12, 0, 0),
+        time: Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end

--- a/spec/expire/backup_spec.rb
+++ b/spec/expire/backup_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Expire::Backup do
   subject do
     described_class.new(
-      time: Time.new(1860, 5, 17, 12, 0, 0),
+      time:     Time.new(1860, 5, 17, 12, 0, 0),
       pathname: Pathname.new('backups/1860-05-17_12_00_00')
     )
   end
@@ -15,7 +15,7 @@ RSpec.describe Expire::Backup do
   describe '#same_hour?' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -23,7 +23,7 @@ RSpec.describe Expire::Backup do
     context 'when the hour is the same' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 17, 12, 11, 22),
+          time:     Time.new(1860, 5, 17, 12, 11, 22),
           pathname: Pathname.new('backups/1860-05-17_12_11_22')
         )
       end
@@ -36,7 +36,7 @@ RSpec.describe Expire::Backup do
     context 'when the hour differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 17, 13, 0, 0),
+          time:     Time.new(1860, 5, 17, 13, 0, 0),
           pathname: Pathname.new('backups/1860-05-17_13_00_00')
         )
       end
@@ -49,7 +49,7 @@ RSpec.describe Expire::Backup do
     context 'when the day differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 22, 12, 0, 0),
+          time:     Time.new(1860, 5, 22, 12, 0, 0),
           pathname: Pathname.new('backups/1860-05-22_12_00_00')
         )
       end
@@ -63,7 +63,7 @@ RSpec.describe Expire::Backup do
   describe '#same_day?' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -71,7 +71,7 @@ RSpec.describe Expire::Backup do
     context 'when the day is the same' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 17, 23, 11, 22),
+          time:     Time.new(1860, 5, 17, 23, 11, 22),
           pathname: Pathname.new('backups/1860-05-17_23_11_22')
         )
       end
@@ -84,7 +84,7 @@ RSpec.describe Expire::Backup do
     context 'when the day differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 18, 13, 0, 0),
+          time:     Time.new(1860, 5, 18, 13, 0, 0),
           pathname: Pathname.new('backups/1860-05-18_13_00_00')
         )
       end
@@ -97,7 +97,7 @@ RSpec.describe Expire::Backup do
     context 'when the month differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 4, 22, 12, 0, 0),
+          time:     Time.new(1860, 4, 22, 12, 0, 0),
           pathname: Pathname.new('backups/1860-04-22_12_00_00')
         )
       end
@@ -111,7 +111,7 @@ RSpec.describe Expire::Backup do
   describe '#same_week?' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -119,7 +119,7 @@ RSpec.describe Expire::Backup do
     context 'when the week is the same' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 15, 12, 0, 0),
+          time:     Time.new(1860, 5, 15, 12, 0, 0),
           pathname: Pathname.new('backups/1860-05-15_12_00_00')
         )
       end
@@ -132,7 +132,7 @@ RSpec.describe Expire::Backup do
     context 'when the week differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 22, 13, 0, 0),
+          time:     Time.new(1860, 5, 22, 13, 0, 0),
           pathname: Pathname.new('backups/1860-05-22_13_00_00')
         )
       end
@@ -145,7 +145,7 @@ RSpec.describe Expire::Backup do
     context 'when the month differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 4, 15, 22, 0, 0),
+          time:     Time.new(1860, 4, 15, 22, 0, 0),
           pathname: Pathname.new('backups/1860-04-15_22_00_00')
         )
       end
@@ -159,7 +159,7 @@ RSpec.describe Expire::Backup do
   describe '#same_month?' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -167,7 +167,7 @@ RSpec.describe Expire::Backup do
     context 'when the month is the same' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 5, 1, 12, 0, 0),
+          time:     Time.new(1860, 5, 1, 12, 0, 0),
           pathname: Pathname.new('backups/1860-01-12_12_00_00')
         )
       end
@@ -180,7 +180,7 @@ RSpec.describe Expire::Backup do
     context 'when the month differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 3, 17, 13, 0, 0),
+          time:     Time.new(1860, 3, 17, 13, 0, 0),
           pathname: Pathname.new('backups/1860-03-17_13_00_00')
         )
       end
@@ -193,7 +193,7 @@ RSpec.describe Expire::Backup do
     context 'when the year differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1859, 5, 17, 12, 0, 0),
+          time:     Time.new(1859, 5, 17, 12, 0, 0),
           pathname: Pathname.new('backups/1860-05-17_12_00_00')
         )
       end
@@ -207,7 +207,7 @@ RSpec.describe Expire::Backup do
   describe '#same_year?' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -215,7 +215,7 @@ RSpec.describe Expire::Backup do
     context 'when the year is the same' do
       let(:other) do
         described_class.new(
-          time: Time.new(1860, 2, 15, 1, 10, 30),
+          time:     Time.new(1860, 2, 15, 1, 10, 30),
           pathname: Pathname.new('backups/1860-05-15_01_10_30')
         )
       end
@@ -228,7 +228,7 @@ RSpec.describe Expire::Backup do
     context 'when the year differs' do
       let(:other) do
         described_class.new(
-          time: Time.new(1859, 5, 17, 12, 0, 0),
+          time:     Time.new(1859, 5, 17, 12, 0, 0),
           pathname: Pathname.new('backups/1859-05-17_12_00_00')
         )
       end
@@ -242,7 +242,7 @@ RSpec.describe Expire::Backup do
   describe '#expired?' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -265,7 +265,7 @@ RSpec.describe Expire::Backup do
   describe '#keep?' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end
@@ -288,7 +288,7 @@ RSpec.describe Expire::Backup do
   describe '#reasons_to_keep' do
     let(:backup) do
       described_class.new(
-        time: Time.new(1860, 5, 17, 12, 0, 0),
+        time:     Time.new(1860, 5, 17, 12, 0, 0),
         pathname: Pathname.new('backups/1860-05-17_12_00_00')
       )
     end

--- a/spec/expire/from_now_keep_daily_for_rule_spec.rb
+++ b/spec/expire/from_now_keep_daily_for_rule_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Expire::FromNowKeepDailyForRule do
   it_behaves_like 'an #apply on a rule' do
     let(:backups) { TestDates.create(days: (15..17), hours: 11..12).to_backups }
     let(:kept) { TestDates.create(days: 16..17).to_backups }
-    let(:reference_datetime) { DateTime.new(1860, 5, 18, 12, 0, 0) }
+    let(:reference_time) { Time.new(1860, 5, 18, 12, 0, 0) }
   end
 
   it_behaves_like 'an unit rule'

--- a/spec/expire/from_now_keep_hourly_for_rule_spec.rb
+++ b/spec/expire/from_now_keep_hourly_for_rule_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Expire::FromNowKeepHourlyForRule do
   it_behaves_like 'an #apply on a rule' do
     let(:backups) { TestDates.create(days: (15..17), hours: 11..12).to_backups }
     let(:kept) { TestDates.create(days: 16..17, hours: 11..12).to_backups }
-    let(:reference_datetime) { DateTime.new(1860, 5, 18, 10, 33, 0) }
+    let(:reference_time) { Time.new(1860, 5, 18, 10, 33, 0) }
   end
 
   it_behaves_like 'an unit rule'

--- a/spec/expire/from_now_keep_monthly_for_rule_spec.rb
+++ b/spec/expire/from_now_keep_monthly_for_rule_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Expire::FromNowKeepMonthlyForRule do
       TestDates.create(years: 1859..1860, months: 4..5).to_backups
     end
 
-    let(:reference_datetime) { DateTime.new(1861, 4, 1, 12, 0, 0) }
+    let(:reference_time) { Time.new(1861, 4, 1, 12, 0, 0) }
   end
 
   it_behaves_like 'an unit rule'

--- a/spec/expire/from_now_keep_most_recent_for_rule_spec.rb
+++ b/spec/expire/from_now_keep_most_recent_for_rule_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Expire::FromNowKeepMostRecentForRule do
   it_behaves_like 'an #apply on a rule' do
     let(:backups) { TestDates.create(days: 15..17).to_backups }
     let(:kept) { TestDates.create(days: 16..17).to_backups }
-    let(:reference_datetime) { DateTime.new(1860, 5, 18, 12, 0, 0) }
+    let(:reference_time) { Time.new(1860, 5, 18, 12, 0, 0) }
   end
 
   it_behaves_like 'a from span-value rule'

--- a/spec/expire/from_now_keep_weekly_for_rule_spec.rb
+++ b/spec/expire/from_now_keep_weekly_for_rule_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Expire::FromNowKeepWeeklyForRule do
       TestDates.create(days: (13..17).step(4), hours: 12..12).to_backups
     end
 
-    let(:reference_datetime) { DateTime.new(1860, 5, 24, 12, 0, 0) }
+    let(:reference_time) { Time.new(1860, 5, 24, 12, 0, 0) }
   end
 
   it_behaves_like 'an unit rule'

--- a/spec/expire/from_now_keep_yearly_for_rule_spec.rb
+++ b/spec/expire/from_now_keep_yearly_for_rule_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Expire::FromNowKeepYearlyForRule do
     let(:kept) do
       TestDates.create(years: 1859..1860).to_backups
     end
-    let(:reference_datetime) { DateTime.new(1861, 5, 10, 12, 0, 0) }
+    let(:reference_time) { Time.new(1861, 5, 10, 12, 0, 0) }
   end
 
   it_behaves_like 'an unit rule'

--- a/spec/expire/keep_daily_for_rule_spec.rb
+++ b/spec/expire/keep_daily_for_rule_spec.rb
@@ -25,6 +25,6 @@ RSpec.describe Expire::KeepDailyForRule do
   it_behaves_like 'an #apply on a rule' do
     let(:backups) { TestDates.create(days: 14..17, hours: 11..12).to_backups }
     let(:kept) { TestDates.create(days: 15..17, hours: 12).to_backups }
-    let(:reference_datetime) { nil }
+    let(:reference_time) { nil }
   end
 end

--- a/spec/expire/keep_hourly_for_rule_spec.rb
+++ b/spec/expire/keep_hourly_for_rule_spec.rb
@@ -25,6 +25,6 @@ RSpec.describe Expire::KeepHourlyForRule do
   it_behaves_like 'an #apply on a rule' do
     let(:backups) { TestDates.create(days: 15..17, hours: 11..12).to_backups }
     let(:kept) { TestDates.create(hours: 11..12).to_backups }
-    let(:reference_datetime) { nil }
+    let(:reference_time) { nil }
   end
 end

--- a/spec/expire/keep_monthly_for_rule_spec.rb
+++ b/spec/expire/keep_monthly_for_rule_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe Expire::KeepMonthlyForRule do
       TestDates.create(months: 3..5, days: (29..29)).to_backups
     end
 
-    let(:reference_datetime) { nil }
+    let(:reference_time) { nil }
   end
 end

--- a/spec/expire/keep_most_recent_for_rule_spec.rb
+++ b/spec/expire/keep_most_recent_for_rule_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Expire::KeepMostRecentForRule do
   it_behaves_like 'an #apply on a rule' do
     let(:backups) { TestDates.create(days: 14..17).to_backups }
     let(:kept) { TestDates.create(days: 15..17).to_backups }
-    let(:reference_datetime) { nil }
+    let(:reference_time) { nil }
   end
 
   it_behaves_like 'a from span-value rule'

--- a/spec/expire/keep_most_recent_rule_spec.rb
+++ b/spec/expire/keep_most_recent_rule_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Expire::KeepMostRecentRule do
 
         allow(backup_one).to receive(:add_reason_to_keep)
 
-        rule.apply(backups, :dummy_reference_datetime)
+        rule.apply(backups, :dummy_reference_time)
       end
 
       it 'adds a reason_to_keep to the most recent backup' do
@@ -51,7 +51,7 @@ RSpec.describe Expire::KeepMostRecentRule do
         allow(backup_one).to receive(:add_reason_to_keep)
         allow(backup_two).to receive(:add_reason_to_keep)
 
-        rule.apply(backups, :dummy_reference_datetime)
+        rule.apply(backups, :dummy_reference_time)
       end
 
       it 'adds a reason_to_keep to the most recent backup' do

--- a/spec/expire/keep_weekly_for_rule_spec.rb
+++ b/spec/expire/keep_weekly_for_rule_spec.rb
@@ -25,6 +25,6 @@ RSpec.describe Expire::KeepWeeklyForRule do
   it_behaves_like 'an #apply on a rule' do
     let(:backups) { TestDates.create(days: (12..20)).to_backups }
     let(:kept) { TestDates.create(days: (13..20).step(7)).to_backups }
-    let(:reference_datetime) { nil }
+    let(:reference_time) { nil }
   end
 end

--- a/spec/expire/keep_yearly_for_rule_spec.rb
+++ b/spec/expire/keep_yearly_for_rule_spec.rb
@@ -31,6 +31,6 @@ RSpec.describe Expire::KeepYearlyForRule do
       TestDates.create(years: 1858..1860, months: (5..5)).to_backups
     end
 
-    let(:reference_datetime) { nil }
+    let(:reference_time) { nil }
   end
 end

--- a/spec/expire/rules_spec.rb
+++ b/spec/expire/rules_spec.rb
@@ -91,12 +91,12 @@ RSpec.describe Expire::Rules do
     end
 
     it 'calls #apply on the first rule' do
-      rules.apply(backups, :dummy_reference_datetime)
+      rules.apply(backups, :dummy_reference_time)
       expect(first_rule).to have_received(:apply)
     end
 
     it 'calls #apply on the second rule' do
-      rules.apply(backups, :dummy_reference_datetime)
+      rules.apply(backups, :dummy_reference_time)
       expect(second_rule).to have_received(:apply)
     end
   end

--- a/spec/support/shared_examples_for_adjective_rules/apply.rb
+++ b/spec/support/shared_examples_for_adjective_rules/apply.rb
@@ -6,8 +6,8 @@ RSpec.shared_examples 'an applicable adjective rule' do
   describe '#apply' do
     let(:backups) do
       backups = TestDates.create(years: 1856..1860).map do |date|
-        datetime = DateTime.new(*date)
-        Expire::Backup.new(datetime: datetime, pathname: Pathname.new('fake/path'))
+        time = Time.new(*date)
+        Expire::Backup.new(time: time, pathname: Pathname.new('fake/path'))
       end
 
       Expire::BackupList.new(backups)
@@ -17,16 +17,16 @@ RSpec.shared_examples 'an applicable adjective rule' do
       let(:rule) { described_class.new(amount: 2) }
 
       it 'keeps 2 backups' do
-        expect(rule.apply(backups, :dummy_reference_datetime).length).to eq(2)
+        expect(rule.apply(backups, :dummy_reference_time).length).to eq(2)
       end
 
       it 'keeps a backup from the year 1860' do
-        expect(rule.apply(backups, :dummy_reference_datetime).first.year)
+        expect(rule.apply(backups, :dummy_reference_time).first.year)
           .to eq(1860)
       end
 
       it 'keeps a backup from the year 1859' do
-        expect(rule.apply(backups, :dummy_reference_datetime).last.year)
+        expect(rule.apply(backups, :dummy_reference_time).last.year)
           .to eq(1859)
       end
 
@@ -36,7 +36,7 @@ RSpec.shared_examples 'an applicable adjective rule' do
       end
 
       it 'adds a reason_to_keep to the second kept backup' do
-        expect(rule.apply(backups, :dummy_reference_datetime)
+        expect(rule.apply(backups, :dummy_reference_time)
           .last.reasons_to_keep)
           .to contain_exactly("keep 2 #{adjective} backups")
       end
@@ -46,7 +46,7 @@ RSpec.shared_examples 'an applicable adjective rule' do
       let(:rule) { described_class.new(amount: 0) }
 
       it 'keeps all backups' do
-        rule.apply(backups, :dummy_reference_datetime)
+        rule.apply(backups, :dummy_reference_time)
         expect(backups.keep_count).to eq(0)
       end
     end
@@ -55,7 +55,7 @@ RSpec.shared_examples 'an applicable adjective rule' do
       let(:rule) { described_class.new(amount: -1) }
 
       it 'keeps all backups' do
-        rule.apply(backups, :dummy_reference_datetime)
+        rule.apply(backups, :dummy_reference_time)
         expect(backups.keep_count).to eq(backups.length)
       end
     end

--- a/spec/support/shared_examples_for_rule_apply.rb
+++ b/spec/support/shared_examples_for_rule_apply.rb
@@ -2,7 +2,7 @@
 
 RSpec.shared_examples 'an #apply on a rule' do
   it 'keeps the expected backups' do
-    subject.apply(backups, reference_datetime)
+    subject.apply(backups, reference_time)
     expect(backups.keep).to contain_exactly(*kept)
   end
 end

--- a/spec/test_dates.rb
+++ b/spec/test_dates.rb
@@ -62,7 +62,7 @@ class TestDates
       pathname = Pathname.new("backups/#{args[0..5].join('_')}")
 
       Expire::Backup.new(
-        datetime: DateTime.new(*args),
+        time: Time.new(*args),
         pathname: pathname
       )
     end
@@ -72,12 +72,12 @@ class TestDates
 
   def to_backup_list
     Expire::BackupList.new(
-      # result.map { |args| Expire::Backup.new(DateTime.new(*args)) }
+      # result.map { |args| Expire::Backup.new(Time.new(*args)) }
       result.map do |args|
         path = "backups/#{args[0..5].join('_')}"
 
         Expire::Backup.new(
-          datetime: DateTime.new(*args),
+          time: Time.new(*args),
           path:     path
         )
       end

--- a/spec/test_dates.rb
+++ b/spec/test_dates.rb
@@ -62,7 +62,7 @@ class TestDates
       pathname = Pathname.new("backups/#{args[0..5].join('_')}")
 
       Expire::Backup.new(
-        time: Time.new(*args),
+        time:     Time.new(*args),
         pathname: pathname
       )
     end
@@ -78,7 +78,7 @@ class TestDates
 
         Expire::Backup.new(
           time: Time.new(*args),
-          path:     path
+          path: path
         )
       end
     )
@@ -87,6 +87,6 @@ class TestDates
   private
 
   def range_for(gizmo)
-    gizmo.class == Integer ? gizmo..gizmo : gizmo
+    gizmo.instance_of?(Integer) ? gizmo..gizmo : gizmo
   end
 end


### PR DESCRIPTION
https://medium.com/swlh/should-i-use-date-time-or-datetime-in-ruby-and-rails-9372ad20ca4f
> DateTime is considered deprecated. It only still exists to be backwards-compatible.